### PR TITLE
:sparkles: Add function to evaluate modified_since criteria at a row level

### DIFF
--- a/tap_spreadsheets_anywhere/file_utils.py
+++ b/tap_spreadsheets_anywhere/file_utils.py
@@ -201,9 +201,8 @@ def evaluate_row_level_date_criteria(target_file_name, table_spec, modified_sinc
             dates_list = [parse(date) for date in records_list if not date is None]             
             max_date_list.append(max(dt for dt in dates_list))
     latest_modified_record = max(dt for dt in max_date_list)
-    #latest_modified_record = max(dates_list)
         
-            # noinspection PyTypeChecker
+    # noinspection PyTypeChecker
     LOGGER.info(modified_since)
     LOGGER.info(latest_modified_record)
     if (modified_since is None or modified_since < latest_modified_record):


### PR DESCRIPTION
Add new functionality to the tap-spreadsheets tap so that we can evaluate the max date from each s3 inventory report and only import those files into the warehouse. The update leverages the existing tap-spreadsheets file timestamp evaluation so for files that have been written to the scrape bucket since the last ELT run, we will then evaluate each of those files, get the max date within each file in the last_modified_date column, and if the max date for this column is also greater than the last ELT run we will process the file. While it will still take time to loop through and evaluate the newly created s3 inventory reports this should help streamline our process and avoid needlessly upserting inventory reports on a regular basis for buckets where there is no activity.